### PR TITLE
Setup clean up

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ requires-dist =
     scipy
     Cython
     astropy (>=1.0)
+    matplotlib
+    ipython
 
 [files]
 packages = imexam

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ requires-dist =
     scipy
     Cython
     astropy (>=1.0)
-    astropy_helpers
 
 [files]
 packages = imexam
@@ -48,3 +47,6 @@ all_files = 1
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1
+
+[ah_bootstrap]
+auto_use = True


### PR DESCRIPTION
This PR changes the setup configuration to:

+ auto-use `astropy-helpers`, so that `ah_bootstrap` will download `astropy_helpers` if needed.
+ removes `astropy-helpers` as a dependency (since the bootstrap process will download it if needed)
+ adds matplotlib and ipython as dependencies, since both are required for importing imexam to succeed.

All of the proposed changes are to make it easier to autobuild conda packages for  astropy affiliated packages. 