### PR TITLE
Change absolute path to relative path

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,8 @@ packages = imexam
 package_data=
     imexam = htmlhelp/*.html htmlhelp/*.js htmlhelp/_images/* htmlhelp/_sources/*.txt
     htmlhelp/_static/* htmlhelp/*.py  htmlhelp/api/* htmlhelp/_modules/*.html
-    htmlhelp/imexam/* /htmlhelp/_sources/api/* 
-    htmlhelp/_sources/imexam/* htmlhelp/_modules/imexam/* 
+    htmlhelp/imexam/* htmlhelp/_sources/api/*
+    htmlhelp/_sources/imexam/* htmlhelp/_modules/imexam/*
 
 [easy_install]
 find-links = http://stsdas.stsci.edu/download/packages


### PR DESCRIPTION
This changes one of the paths in ``setup.cfg`` from absolute to relative. The current version fails to install on Windows because of the absolute path.

If you could do another pypi release after this that would be great....right now I can't build 0.5.1 for the conda affiliated package channel because of this. 