### PR TITLE
Let missing Popen still allow exception to pass through

### DIFF
--- a/imexam/ds9_viewer.py
+++ b/imexam/ds9_viewer.py
@@ -493,11 +493,17 @@ class ds9(object):
             return xpaname
 
         except Exception as e:  # refine error class
-            warnings.warn("Opening  ds9 failed")
+            warnings.warn("Opening ds9 failed")
             print("Exception: {}".format(repr(e)))
             from signal import SIGTERM
-            os.kill(p.pid, SIGTERM)
-            raise Exception
+            try:
+                pidtokill = p.pid
+            except NameError:
+                # in case p failed at the initialization level
+                pidtokill = None
+            if pidtokill is not None:
+                os.kill(pidtokill, SIGTERM)
+            raise e
 
     def _run_unixonly_ds9(self):
         """ start new ds9 window and connect to object using a unix socket


### PR DESCRIPTION
This is the fix for the second error I encountered as part of #44 .  It turns out there was an ``except`` block that assumes a `Popen` call succeeds, but if the ``ds9`` executable is in some manner invalid, that never gets called.  So this just alters the ``except`` block to account for that possibility by not killing the associated process (which should be safe because it failed to be created in the first place).

#45 in addition to this should close #44