### PR TITLE
Adding conda channels to CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-    
+
 python:
     - 2.7
     - 3.4
@@ -29,6 +29,7 @@ env:
         - PIP_DEPENDENCIES='photutils'
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
+        - CONDA_CHANNELS='astropy-ci-extras astropy'
 
     matrix:
         # make sure that egg_info works without dependencies
@@ -72,7 +73,7 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.10
         - python: 2.7
-          env: NUMPY_VERSION=1.9           
+          env: NUMPY_VERSION=1.9
         - python: 3.5
           env: NUMPY_VERSION=1.10
         - python: 3.5
@@ -99,12 +100,12 @@ matrix:
         # showing any obvious reason, thus allowing it to fail for now.
         - python: 3.5
           env: NUMPY_VERSION=prerelease
-        # The build completes and the tests collect and then 
+        # The build completes and the tests collect and then
         # it just stops with no error, same as above
         - python: 3.5
           env: NUMPY_VERSION=1.9
         - python: 2.7
-          env: NUMPY_VERSION=1.9           
+          env: NUMPY_VERSION=1.9
 
 
 before_install:
@@ -115,7 +116,7 @@ before_install:
     - sleep 3
     - uname -a
     - python --version
-    
+
     # We now use the ci-helpers package to set up our testing environment.
     # This is done by using Miniconda and then using conda and pip to install
     # dependencies. Which dependencies are installed using conda and pip is
@@ -132,7 +133,7 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
     - pip install pytest-pep8
-    
+
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some
     # cases this may not provide enough flexibility in how to install a
@@ -145,7 +146,7 @@ install:
 
 script:
     - $MAIN_CMD  $SETUP_CMD
-    
-    
+
+
 after_success:
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='imexam/tests/coveragerc'; fi


### PR DESCRIPTION
Conda channels now need to be explicitly listed, ci-helpers won't add astropy and astropy-ci-extras by default in the future astropy/ci-helpers#128.