### PR TITLE
Eteq make list return - updated pull 

### DIFF
--- a/imexam/util.py
+++ b/imexam/util.py
@@ -48,7 +48,7 @@ def list_active_ds9(verbose=True):
     Parameters
     ----------
     verbose : bool
-        If True, prints out all the information about what ds9s are active.
+        If True, prints out all the information about what DS9 windows are active.
 
     Returns
     -------
@@ -63,33 +63,32 @@ def list_active_ds9(verbose=True):
     seeing it when I call this function. I think because it's only
     listening on the inet socket which starts by default in the OS.
     That's if xpans is installed on the machine. Otherwise, no
-    nameserver is running at all.
+    nameserver is running at all. This helps with object cont
     """
-    session_list = []
+    session_dict = {}
 
     # only run if XPA/xpans is installed on the machine
     if find_xpans():
+        sessions = None
         try:
-            sessions = xpa.get(b"xpans")
-            if sessions is None and verbose:
-                print("No active sessions")
-            if len(sessions) < 1 and verbose:
+            sessions = xpa.get(b"xpans").decode().strip().split("\n")
+            if ((sessions is None or len(sessions) < 1) and verbose):
                 print("No active sessions")
             else:
-                for line in sessions.decode().split('\n'):
-                    if line.strip() != '':
-                        session_list.append(sessions.decode().split())
+                for line in sessions:
+                    classn, name, access, ids, user = tuple(line.split())
+                    session_dict[ids] = (name, user, classn, access)
                 if verbose:
-                    print(sessions.decode())
+                    for line in sessions:
+                        print(line)
         except xpa.XpaException:
-            if verbose:
                 print("No active sessions registered")
 
-    elif verbose:
+    else:
         print("XPA nameserver not installed or not on PATH, \
                function unavailable")
 
-    return session_list
+    return session_dict
 
 
 def display_help():


### PR DESCRIPTION
@eteq  your original pull is incorporated in this, but I've changed the return to a dictionary to try and help users know what information the xpa is after for connection. 

You can connect an already open window by specifying the title or the XPA_METHOD. If users don't specify a title in the ds9 window when they open one up, ds9 will just call it "ds9", so you can end up with multiple windows with the same name. This works for DS9 because the XPA_METHOD is always unique. The most straightforward way is for users to open the DS9 windows with explicit titles, and then tell imexam to connect to that window:

```
python> !ds9 -title megan
python> window=imexam.connect('megan')
```

However, it there are windows already open with no unique titles, the best way is to connect using the method. This dictionary returns the information for all the windows, but it's keys are the unique XPA_METHOD strings.

```
In [3]: !ds9&

In [4]: imexam.list_active_ds9()
DS9 ds9 gs c0a80106:61894 sosey
Out[4]: {'c0a80106:61894': ('ds9', 'sosey', 'DS9', 'gs')}

```

It's not necessarily more straightforward with the dict, but this way you can return the list of windows you can connect to without too much thinking:

```
In [1]: import imexam

In [2]: windows=imexam.list_active_ds9()
DS9 ds9 gs c0a80106:61915 sosey

In [3]: list(windows)
Out[3]: ['c0a80106:61915']

In [4]: !ds9&

In [5]: windows=imexam.list_active_ds9()
DS9 ds9 gs c0a80106:61915 sosey
DS9 ds9 gs c0a80106:61923 sosey

In [6]: list(windows)
Out[6]: ['c0a80106:61915', 'c0a80106:61923']

In [7]: ds9=imexam.connect(list(windows)[0])
```

But you can also use it a little easier to cycle through connecting to a set of windows:

```
In [8]: windows=imexam.list_active_ds9()
DS9 ds9 gs c0a80106:61915 sosey
DS9 ds9 gs c0a80106:61923 sosey

In [9]: ds=imexam.connect(windows.popitem()[0]) #connect to first window, remove as possible window
In [10]: windows
Out[11]: {'c0a80106:61923': ('ds9', 'sosey', 'DS9', 'gs')}

In [12]: w2=imexam.connect(windows.popitem()[0])

In [13]: windows
Out[31]: {}
```
@emcangi  How do you feel about this sort of interaction, would it work for you as well?

