### PR TITLE
windows install to ignore the xpa compile and ds9

### DIFF
--- a/imexam/__init__.py
+++ b/imexam/__init__.py
@@ -10,10 +10,18 @@ viewing tool, like DS9
 from ._astropy_init import *
 # ----------------------------------------------------------------------------
 
+try:
+    from .xpa_wrap import XPA
+    _have_xpa = True
+except ImportError:
+    _have_xpa = False
+
 if not _ASTROPY_SETUP_:
     # import high level functions into the imexam namespace
-    from .util import list_active_ds9
-    from .util import display_help, display_xpa_help
+    if _have_xpa:
+        from .util import list_active_ds9
+        from .util import display_help, display_xpa_help
+
     from .util import set_logging
     from . import connect as _connect
     connect = _connect.Connect

--- a/imexam/connect.py
+++ b/imexam/connect.py
@@ -12,7 +12,7 @@ import os
 import astropy
 
 from .util import set_logging
-from .ds9_viewer import ds9
+
 try:
     from .ginga_viewer import ginga
     have_ginga = True
@@ -22,6 +22,7 @@ except ImportError:
 try:
     from .xpa_wrap import XPA
     have_xpa = True
+    from .ds9_viewer import ds9
 except ImportError:
     have_xpa = False
 

--- a/imexam/connect.py
+++ b/imexam/connect.py
@@ -19,6 +19,12 @@ try:
 except ImportError:
     have_ginga = False
 
+try:
+    from .xpa_wrap import XPA
+    have_xpa = True
+except ImportError:
+    have_xpa = False
+
 from .imexamine import Imexamine
 
 __all__ = ["Connect"]
@@ -64,15 +70,17 @@ class Connect(object):
     def __init__(self, target=None, path=None, viewer="ds9",
                  wait_time=10, quit_window=True, port=None):
         """Initialize the imexam control object."""
-        # better dynamic way so people can add their own viewers?
-        _possible_viewers = ["ds9"]
+        _possible_viewers = []
 
-        self._viewer = viewer.lower()
+        if have_xpa:
+            _possible_viewers = ["ds9"]
 
         if have_ginga:
             _possible_viewers.append('ginga')
 
-        if self._viewer not in _possible_viewers:
+        self._viewer = viewer.lower()
+
+        if (self._viewer not in _possible_viewers or len(_possible_viewers) == 0):
             warnings.warn("**Unsupported viewer, check your installed packages**\n")
             raise NotImplementedError
 

--- a/imexam/util.py
+++ b/imexam/util.py
@@ -8,16 +8,16 @@ import logging
 import warnings
 from astropy.io import fits
 
-import xpa
+try:
+    from .xpa_wrap import XPA
+    _have_xpa = True
+except ImportError:
+    _have_xpa = False
+
 from .version import version as __version__
 
 # To guide any import *
-__all__ = [
-    "find_ds9",
-    "list_active_ds9",
-    "display_help",
-    "find_xpans",
-    "set_logging"]
+__all__ = ["display_help", "set_logging"]
 
 
 def find_ds9():

--- a/imexam/util.py
+++ b/imexam/util.py
@@ -99,7 +99,7 @@ def display_help():
         import webbrowser
         # grab the version that's installed
         if "dev" not in __version__:
-            url += "en/{0:s}/".format(__version__)
+            url += "en/v{0:s}/".format(__version__)
         webbrowser.open(url)
     except ImportError:
         warnings.warn(


### PR DESCRIPTION
@pllim try this on your windows machine and verify that it works?

This should ignore the XPA compile for windows machines, the package import and connect should see that no xpa is available, and check if ginga *is* available and otherwise return a viewer error message.

So windows users should be able to install this and have access to ginga as the viewer instead of DS9.