### PR TITLE
Release for v0.7.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,10 +20,12 @@ version 0.6.3 (released)
 - Documentation and the jupyter examples updated
 - Fixed bug with loading user specified fits extensions for both ginga and ds9
 
+
 version 0.6.2 (released)
 ------------------------
 - Unbinned radial plots were added, bins are still an available option
 - documentation updates
+
 
 version 0.6dev (unreleased)
 ---------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,15 @@
 
+version 0.7.0 (released)
+-----------------------------
+- fixed a text error in the display_help() so that now the correct version loads the documentation
+- Windows users can now install from source. The setup will ignore the cython and xpa necessary to build the DS9 interaction, and users will only be able to use the Ginga HTML5 window, they can also use the Imexamine() functions without any graphical interface.
+- Documentation updates, mostly specific information for Windows users
+- Added python 3.6 to the test matrix as well as apveyor for the windows build
+- Updated XPA module to v2.1.18
+- Made fits checker smarter to deal with older simple fits files where EXTEND is true but there are no extensions
+- fixed bug in fits loader for ds9 multi-extension FITS files, made load_fits() prefer the extension specified in the key rather than the image name
+
+
 
 version 0.6.4dev (unreleased)
 -----------------------------

--- a/docs/imexam/imexam_command.rst
+++ b/docs/imexam/imexam_command.rst
@@ -230,7 +230,7 @@ If you press the "m" key, the  pixel values around the pointer location are calc
 The user can map the function to any reasonable numpy function, it's set to numpy.median by default::
 
     report_stat_pars= {"function":["report_stat",],
-                        "stat":["median","which numpy stat to return [median,min,max...must map to numpy func]"],
+                        "stat":["median","numpy stat name or describe for scipy.stats"],
                         "region_size":[5,"region size in pixels to use"],
                     }
 

--- a/imexam/imexam_defpars.py
+++ b/imexam/imexam_defpars.py
@@ -21,7 +21,7 @@ aper_phot_pars = {"function": ["aper_phot", ],
 
 # box statistics
 report_stat_pars = {"function": ["report_stat", ],
-                    "stat": ["median", "which numpy stat to return [median, min, max]"],
+                    "stat": ["median", "numpy stat name or describe for scipy.stats"],
                     "region_size": [5, "region size in pixels to use"],
                     }
 

--- a/imexam/imexamine.py
+++ b/imexam/imexamine.py
@@ -319,9 +319,9 @@ class Imexamine(object):
             ax.set_yscale("log")
 
         if bool(self.lineplot_pars["pointmode"][0]):
-            ax.plot(data[y, :], self.lineplot_pars["marker"][0])
+            ax.plot(data[int(y), :], self.lineplot_pars["marker"][0])
         else:
-            ax.plot(data[y, :])
+            ax.plot(data[int(y), :])
 
         if pfig is None and 'nbagg' not in get_backend().lower():
             plt.draw()
@@ -373,9 +373,9 @@ class Imexamine(object):
         if self.colplot_pars["logy"][0]:
             ax.set_yscale("log")
         if bool(self.colplot_pars["pointmode"][0]):
-            ax.plot(data[:, x], self.colplot_pars["marker"][0])
+            ax.plot(data[:, int(x)], self.colplot_pars["marker"][0])
         else:
-            ax.plot(data[:, x])
+            ax.plot(data[:, int(x)])
 
         if pfig is None and 'nbagg' not in get_backend().lower():
             plt.draw()
@@ -431,7 +431,7 @@ class Imexamine(object):
                 nobs, minmax, mean, var, skew, kurt = stat(data[ymin:ymax,
                                                            xmin:xmax].flatten())
                 pstr = ("[{0:d}:{1:d},{2:d}:{3:d}] {4:s}: \nnobs: "
-                        "{5}\nminamx: {6}\nmean {7}\nvariance: {8}\nskew: "
+                        "{5}\nminmax: {6}\nmean {7}\nvariance: {8}\nskew: "
                         "{9}\nkurtosis: {10}".format(ymin, ymax, xmin, xmax,
                                                      name, nobs, minmax, mean,
                                                      var, skew, kurt))

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.6.4dev'
+VERSION = '0.7.0'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
- fixed a text error in the display_help() so that now the correct version loads the documentation
- Windows users can now install from source. The setup will ignore the cython and xpa necessary to build the DS9 interaction, and users will only be able to use the Ginga HTML5 window, they can also use the Imexamine() functions without any graphical interface.
- Documentation updates, mostly specific information for Windows users
- Added python 3.6 to the test matrix as well as apveyor for the windows build
- Updated XPA module to v2.1.18
- Made fits checker smarter to deal with older simple fits files where EXTEND is true but there are no extensions
- fixed bug in fits loader for ds9 multi-extension FITS files, made load_fits() prefer the extension specified in the key rather than the image name
