### PR TITLE
Adding field 'install_requires' to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     requires=['astropy'],
+    install_requires=['astropy'],
     provides=[PACKAGENAME],
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
I think this will solve the issue I'm seeing while building the conda package using the standard recipe skeleton, e.g.:

https://travis-ci.org/astropy/conda-channel-astropy/jobs/194838964#L1473

(having ``requires`` in the setup.py is probably superfluous but harmless, so I've left it in there, too).

