### PR TITLE
added cube support for view method in ds9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
-language: python
+language: c
 
-
-python:
-    - 2.7
-    - 3.5
+os:
+    - linux
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -22,6 +20,7 @@ addons:
 env:
     global:
         # SET DEFAULTS TO AVOID REPEATING IN MOST CASES
+        - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='Cython matplotlib scipy ipython'
@@ -29,12 +28,14 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
+        - SETUP_XVFB=True
+        - EVENT_TYPE='push pull_request'
 
     matrix:
         # make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test -v'
+        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
 
 matrix:
@@ -43,7 +44,14 @@ matrix:
     fast_finish: true
 
     include:
+        # Try MacOS X
+        - os: osx
+          env: SETUP_CMD='test'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
+               PIP_DEPENDENCIES=$PIP_DEPENDENCIES
 
+
+        - os: linux
         # Check for sphinx doc build warnings - we do this first because
         # it may run for a long time. Need to use sphinx <1.6 until photutils 0.4 is out.
         - python: 2.7
@@ -99,6 +107,8 @@ matrix:
         # showing any obvious reason, thus allowing it to fail for now.
         - python: 3.5
           env: NUMPY_VERSION=prerelease
+        - python: 3.6
+          env: SETUP_CMD='build_sphinx -w' CONDA_DEPENDENCIES='Cython ipython scipy matplotlib ginga'
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,16 +77,10 @@ matrix:
 
 
         # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.10
-        - python: 2.7
-          env: NUMPY_VERSION=1.9
-        - python: 3.5
-          env: NUMPY_VERSION=1.10
-        - python: 3.5
-          env: NUMPY_VERSION=1.9
         - python: 3.5
           env: NUMPY_VERSION=1.11
+        - python: 3.5
+          env: NUMPY_VERSION=1.12
 
 
         # Try numpy pre-release

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ version 0.7.2dev (unreleased)
   to the xpa library
 - fixed logic of connect method. When a target is given, do not look
   for an executable
+- view method now supports loading cubes when there are 3 dimension in the given array
+- logic bug in ds9 class init updated to warn when user specified target doesn't exist
 
   
 version 0.7.1 (released)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
         PYTHON: "C:\\conda"
         MINICONDA_VERSION: "latest"
         CONDA_DEPENDENCIES: "scipy matplotlib numpy astropy ipython"
+        ASTROPY_USE_SYSTEM_PYTEST: 1
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
@@ -17,7 +18,10 @@ environment:
         - PYTHON_VERSION: "2.7"
           NUMPY_VERSION: "stable"
         - PYTHON_VERSION: "3.5"
+          NUMPY_VERION: "stable"
+        - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
+        - ASTROPY_USE_SYSTEM_PYTEST: 1
 
 matrix:
     fast_finish: true
@@ -26,6 +30,7 @@ matrix:
 platform:
     -x64
 
+os: Visual Studio 2015 Update 2
 
 install:
     - "git clone git://github.com/astropy/ci-helpers.git"
@@ -35,3 +40,6 @@ install:
 
 # Not a .NET project, we build in the install step instead
 build: false
+
+test_script:
+    - "%CMD_IN_ENV% python setup.py test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ environment:
           NUMPY_VERION: "stable"
         - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
-        - ASTROPY_USE_SYSTEM_PYTEST: 1
 
 matrix:
     fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ matrix:
 platform:
     -x64
 
-os: Visual Studio 2015 Update 2
+# os: Visual Studio 2015 Update 2
 
 install:
     - "git clone git://github.com/astropy/ci-helpers.git"

--- a/imexam/ds9_viewer.py
+++ b/imexam/ds9_viewer.py
@@ -50,7 +50,6 @@ from astropy.io import fits
 class UnsupportedDatatypeException(Exception):
     pass
 
-
 class UnsupportedImageShapeException(Exception):
     pass
 
@@ -206,7 +205,6 @@ class ds9(object):
         # An existing ds9 was suggested. Confirm existence
         # and attach.
         if target:
-
             # check to see if the target exists
             active = util.list_active_ds9(False)
             if target in list(active):
@@ -224,8 +222,6 @@ class ds9(object):
                     "Please choose an existing target."
                 )
 
-        # If an existing ds9 is not specified,
-        # fire one up.
         else:
             if not path:
                 self._ds9_path = util.find_ds9()
@@ -1723,9 +1719,17 @@ class ds9(object):
             if img.dtype.type == np.bool8:
                 img = img.astype(np.uint8)
 
-            try:
-                img.shape = img.shape[-2:]
-            except:
+            # arrays of 1 through 3 dimensions
+            dim = img.ndim
+            if dim == 2:
+                (ydim, xdim) = img.shape
+                dims = "[xdim={0:d},ydim={1:d},".format(xdim, ydim)
+            elif dim == 3:
+                (ydim, xdim, zdim) = img.shape
+                dims = "[xdim={0:d},ydim={1:d},zdim={2:d},".format(xdim,
+                                                                   ydim,
+                                                                   zdim)
+            else:
                 raise UnsupportedImageShapeException(repr(img.shape))
 
             if img.dtype.byteorder in ["=", "|"]:
@@ -1737,7 +1741,7 @@ class ds9(object):
 
             endianness = {">": ",arch=bigendian",
                           "<": ",arch=littleendian"}[byteorder]
-            (ydim, xdim) = img.shape
+
             arr_str = img.tostring()
 
             try:
@@ -1745,9 +1749,7 @@ class ds9(object):
             except KeyError as e:
                 raise UnsupportedDatatypeException(e)
 
-            option = ("[xdim={0:d},ydim={1:d},"
-                      "bitpix={2:d}{3:s}]".format(xdim, ydim,
-                                                  bitpix, endianness))
+            option = (dims + "bitpix={0:d}{1:s}]".format(bitpix, endianness))
             try:
                 self.set("array " + option, arr_str)
                 self._set_frameinfo()
@@ -1789,7 +1791,11 @@ class ds9(object):
 
     def show_xpa_commands(self):
         """Print the available XPA commands."""
+<<<<<<< HEAD
         print(self.get(''))  # With empty string, all commands are returned
+=======
+        print(self.get(''))  # with no arguments supplied, XPA returns options
+>>>>>>> added cube support for view method in ds9
 
     def reopen(self):
         """Reopen a closed window."""

--- a/imexam/ds9_viewer.py
+++ b/imexam/ds9_viewer.py
@@ -1792,11 +1792,8 @@ class ds9(object):
 
     def show_xpa_commands(self):
         """Print the available XPA commands."""
-<<<<<<< HEAD
         print(self.get(''))  # With empty string, all commands are returned
-=======
-        print(self.get(''))  # with no arguments supplied, XPA returns options
->>>>>>> added cube support for view method in ds9
+        
 
     def reopen(self):
         """Reopen a closed window."""

--- a/imexam/ds9_viewer.py
+++ b/imexam/ds9_viewer.py
@@ -50,6 +50,7 @@ from astropy.io import fits
 class UnsupportedDatatypeException(Exception):
     pass
 
+
 class UnsupportedImageShapeException(Exception):
     pass
 
@@ -1725,7 +1726,7 @@ class ds9(object):
                 (ydim, xdim) = img.shape
                 dims = "[xdim={0:d},ydim={1:d},".format(xdim, ydim)
             elif dim == 3:
-                (ydim, xdim, zdim) = img.shape
+                (zdim, ydim, xdim) = img.shape
                 dims = "[xdim={0:d},ydim={1:d},zdim={2:d},".format(xdim,
                                                                    ydim,
                                                                    zdim)


### PR DESCRIPTION
cube arrays can now be loaded using the view() method in DS9. If there are 3 dimensions, the cube dialog will open automatically in DS9.

``` 
import numpy as np
import imexam
rancube = np.ones([50, 50, 50]) * np.random.rand(50)
a=imexam.connect()
a.view(rancube)
a.zoom()
a.close()
```
It could be made more general. Right now it support 2 and 3 dimensional arrays, need to figure out the better way to support (y,x,z,n) arrays like this: 
```
Filename: test_cube.fits
No.    Name         Type      Cards   Dimensions   Format
0    PRIMARY     PrimaryHDU     215   ()
1    SCI         ImageHDU        13   (1032, 1024, 35, 5)   int16
2    REFOUT      ImageHDU        13   (258, 1024, 35, 5)   int16
```