### PR TITLE
Update astropy-helpers to v2.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ matrix:
 
        # Try Astropy development and LTS versions
         - python: 2.7
-          env: ASTROPY_VERSION=development
-        - python: 2.7
           env: ASTROPY_VERSION=lts
         - python: 3.5
           env: ASTROPY_VERSION=lts

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,13 @@ matrix:
     include:
 
         # Check for sphinx doc build warnings - we do this first because
-        # it may run for a long time
+        # it may run for a long time. Need to use sphinx <1.6 until photutils 0.4 is out.
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w' CONDA_DEPENDENCIES='Cython ipython scipy matplotlib ginga'
+               SPHINX_VERSION=1.5.6
         - python: 3.5
           env: SETUP_CMD='build_sphinx -w' CONDA_DEPENDENCIES='Cython ipython scipy matplotlib ginga'
-
+               SPHINX_VERSION=1.5.6
 
        # Try Astropy development and LTS versions
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,11 +85,9 @@ matrix:
         - python: 3.5
           env: NUMPY_VERSION=prerelease
 
-        # Do a coverage test in Python 2. This requires the latest
-        # development version of Astropy, which fixes some issues with
-        # coverage testing in affiliated packages.
+        # Do a coverage test in Python 2.
         - python: 2.7
-          env: SETUP_CMD='test --coverage' ASTROPY_VERSION=development
+          env: SETUP_CMD='test --coverage'
 
 
         # Do a pep8 test


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v2.0.2. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!*