### PR TITLE
update travis config so that xvfb selects free display automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,8 +108,7 @@ matrix:
 before_install:
 
     # CONFIGURE A HEADLESS DISPLAY TO TEST PLOT GENERATION
-    - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
+    - xvfb-run -a
     - sleep 3
     - uname -a
     - python --version

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ after you have cloned the repository and before you "python setup.py install"
     git submodule update --init -- cextern/xpa
 
 
-If you are cloneing the repository for the first time, you can do both steps at once using a recursive clone:
+If you are cloning the repository for the first time, you can do both steps at once using a recursive clone:
 
 ::
 


### PR DESCRIPTION
Travis no longer allows starting xvfb as a service, this update uses xvfb-run instead as well as the "a" option to remove display port collisions for concurrent runs