### PR TITLE
added an alias check for the ds9 path

### DIFF
--- a/imexam/conftest.py
+++ b/imexam/conftest.py
@@ -1,5 +1,3 @@
-
-
 # Uncomment the following lines to display the version number of the
 # package rather than the version number of Astropy in the top line when
 # running the tests.

--- a/imexam/conftest.py
+++ b/imexam/conftest.py
@@ -20,3 +20,4 @@ pytest_plugins = [
 ]
 
 enable_deprecations_as_exceptions()
+

--- a/imexam/ds9_viewer.py
+++ b/imexam/ds9_viewer.py
@@ -225,7 +225,7 @@ class ds9:
             if not path:
                 self._ds9_path = util.find_path('ds9')
                 if not self._ds9_path:
-                    raise OSError("Could not find ds9 executable on your path")
+                    raise OSError("Could not find ds9 executable on your path or alias")
 
             else:
                 self._ds9_path = path
@@ -471,7 +471,7 @@ class ds9:
     def _stop_process(self):
         """stop the ds9 window process nicely.
 
-        only if this package started it
+        but only if this package started it
         """
         try:
             if self._ds9_process:

--- a/imexam/ginga_viewer.py
+++ b/imexam/ginga_viewer.py
@@ -15,15 +15,17 @@ import numpy as np
 from . import util
 from astropy.io import fits
 
-from ginga.misc import log, Settings
-from ginga.AstroImage import AstroImage
-from ginga.BaseImage import BaseImage
-from ginga import cmap
-from ginga.util import paths
-from ginga.util import wcsmod
+try:
+    from ginga.misc import log, Settings
+    from ginga.AstroImage import AstroImage
+    from ginga.BaseImage import BaseImage
+    from ginga import cmap
+    from ginga.util import paths
+    from ginga.util import wcsmod
+    wcsmod.use('AstropyWCS')
+except ImportError:
+    print("Ginga not installed, use other viewer, or no viewer")
 
-
-wcsmod.use('AstropyWCS')
 
 # module variables
 _matplotlib_cmaps_added = False

--- a/imexam/util.py
+++ b/imexam/util.py
@@ -13,15 +13,38 @@ __all__ = ["display_help", "set_logging"]
 
 
 def find_path(target=None):
-    """Find the local path to the target executable"""
-    if target is None:
-        raise TypeError("Expected name of executable")
+    """Find the local path to the target executable.
 
+    Parameters
+    ----------
+    target: None or str
+        The name of the executable to find
+
+    Returns
+    -------
+    The path to the executable or None if not found
+
+    Notes
+    -----
+    This will first look for the target on the users
+    path and then look to see if an alias has been
+    set. It assumes that the user has aliased ds9 to
+    the same name, ds9. If otherwise, the user should
+    specify path in the call to the connect() method.
+    """
+
+    if target is None:
+        raise TypeError("Expected name of target executable")
+
+    found_path = None
     for dirname in os.getenv("PATH").split(":"):
         possible = os.path.join(dirname, target)
         if os.path.isfile(possible):
-            return possible
-    return None
+            found_path = possible
+    if found_path is None:
+        # This will also return None if not set
+        found_path = os.getenv(target)
+    return found_path
 
 
 def list_active_ds9(verbose=True):


### PR DESCRIPTION
see #167 

This adds a check to see if the user aliased the executable for ds9. It will first look for ds9 on the PATH and then on the alias. If users want otherwise they should specify using the path argument to connect()