### PR TITLE
Update rtd build file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,34 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+build:
+  image: latest
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - requirements: docs/rtd-pip-requirements
+      - method: pip
+        path: .
+        extra_requirements:
+            - docs
+      - method: setuptools
+        path: .
+   system_packages: false
+
+submodules:
+   include: all

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,10 @@ if sys.version_info[0] == 2:
         os.path.abspath(os.path.join(os.path.dirname(__file__),
                                      'local/python2_local_links.inv')))
 
+
+# suppress  epub errors for static file formats (.ico) on rtd
+suppress_warnings = ['epub.unknown_project_files']
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.


### PR DESCRIPTION
This updates the RTD documentation build to use the latest v2 version of the test runner and closes #183 