### PR TITLE
Add autoscale option to ds9 load_fits

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,34 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+build:
+  image: latest
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - requirements: docs/rtd-pip-requirements
+      - method: pip
+        path: .
+        extra_requirements:
+            - docs
+      - method: setuptools
+        path: .
+   system_packages: false
+
+submodules:
+   include: all

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ version 0.8.2a (unreleased)
 - add check for ds9 in alias as well as well as path
 - python2->3 class and printing updates
 - removed dependence on astropy_helpers
+- added autoscale option to the ds9 load_fits that will zoom-to-fit and zscale by default
 
 version 0.8.1 (2018-12-14)
 --------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,10 @@ if sys.version_info[0] == 2:
         os.path.abspath(os.path.join(os.path.dirname(__file__),
                                      'local/python2_local_links.inv')))
 
+
+# suppress  epub errors for static file formats (.ico) on rtd
+suppress_warnings = ['epub.unknown_project_files']
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/imexam/ds9_viewer.py
+++ b/imexam/ds9_viewer.py
@@ -1118,7 +1118,7 @@ class ds9:
         """Embed the viewer in a notebook."""
         print("Not Implemented for DS9")
 
-    def load_fits(self, fname, extver=None, mecube=False):
+    def load_fits(self, fname, extver=None, mecube=False, autoscale=True):
         """convenience function to load fits image to current frame.
 
         Parameters
@@ -1134,6 +1134,10 @@ class ds9:
 
         mecube: bool, optional
             If mecube is True, load the fits file as a cube into ds9
+
+        autoscale: bool
+            If true, the image will be autoscaled to zoom-to-fit as well
+            as flux autoscaled upon load
 
         Notes
         -----
@@ -1192,6 +1196,9 @@ class ds9:
             self._viewer[frame]['user_array'] = None
         else:
             self.view(fname[extver].data)
+        if autoscale:
+            self.zoom()
+            self.scale()
 
     def load_region(self, filename):
         """Load regions from a file which uses ds9 standard formatting.


### PR DESCRIPTION
`autoscale=True` was added as a default option to the ds9 `load_fits` method, this will zscale() the flux and zoom-to-fit the image unless set to false. 