### PR TITLE
Add requirement on packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ tests =
 
 photometry =
     photutils
+    packaging
 
 [build-system]
 requires = ["cython"]


### PR DESCRIPTION
Checking the version of `photutils` requires the `packaging` module.
See:
 https://github.com/spacetelescope/imexam/blob/da7e3c57cc51a4bf5a31ad444ff44c8b7e3f216f/imexam/imexamine.py#L67

I happened to have `photutils` installed, but it was not detected by `imexam` becase trying to import `packaging` was throwing `ImportError`.