### PR TITLE
line_fit: round centroid co-ord float to int, rather than truncate

### DIFF
--- a/imexam/imexamine.py
+++ b/imexam/imexamine.py
@@ -771,8 +771,9 @@ class Imexamine:
                         self.log.warning("Problem with centering, "
                                          "pixel coords")
                 else:
-                    xx = int(xout)
-                    yy = int(yout)
+                    # +0.5 ensures rounding float->int, rather than truncating
+                    xx = int(xout+0.5)
+                    yy = int(yout+0.5)
         if col:
             line = data[:, xx]
             chunk = line[yy - delta:yy + delta]


### PR DESCRIPTION
Line_fit (and thus col_fit) truncate the centroid float co-ordinates to ints (the ints are used to access the array position). For example, I have a star with centroid `xout=581.24`, `yout=1906.72`. It was being truncated to `xx=581` correctly, but `yy=1906` incorrectly - the peak pixel at y=1907 is excluded. I believe `yy` should be rounded to 1907 instead, to ensure the line_fit/col_fit includes the peak pixel.

In-built conversion from float to int is a flooring function, so changing `xx=int(xout)` to `xx=int(xout+0.5)` (and same for y) ensures values of decimal >= .5 will get rounded correctly upwards, rather than truncated downwards. 

This doesn't work for negative x or y, but this is an unlikely situation? If not, it is easily implemented: if x or y <0, subtract 0.5 instead.