### PR TITLE
MNT: Update codecov-action version to v2

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -57,6 +57,6 @@ jobs:
       run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov
       if: "contains(matrix.tox_env, '-cov')"
-      uses: codecov/codecov-action@v1.0.13
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml


### PR DESCRIPTION
You are using a deprecated version of `codecov-action`, see https://github.com/codecov/codecov-action for more details. xref astropy/astropy#12245

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.