### PR TITLE
Fixed L649 to show fwhmx and fwhmy 

### DIFF
--- a/imexam/imexamine.py
+++ b/imexam/imexamine.py
@@ -646,7 +646,7 @@ class Imexamine:
                 else:
                     pheader += "fwhm(x,y)"
                     fwhmx, fwhmy = math_helper.gfwhm(sigma, sigmay)
-                    pstr += f"{sigma:0.2f},{sigmay:0.2f}"
+                    pstr += f"{fwhmx:0.2f},{fwhmy:0.2f}"
 
             pheader = pheader.expandtabs(15)
             pstr = pstr.expandtabs(15)


### PR DESCRIPTION
fwhm(x,y) of the output of aimexam shows sigma and sigmay instead of fwhmx and fwhmy. 
Fixed L649 to show fwhmx and fwhmy

Thanks 

